### PR TITLE
Edits to enable usage of RDS/S3 Terraform Module outside of this repo

### DIFF
--- a/charts/apps/training-operator/templates/Deployment/training-operator-kubeflow-Deployment.yaml
+++ b/charts/apps/training-operator/templates/Deployment/training-operator-kubeflow-Deployment.yaml
@@ -50,7 +50,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
             memory: 20Mi

--- a/charts/apps/training-operator/templates/Deployment/training-operator-kubeflow-Deployment.yaml
+++ b/charts/apps/training-operator/templates/Deployment/training-operator-kubeflow-Deployment.yaml
@@ -53,7 +53,7 @@ spec:
             memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 100Mi
         securityContext:
           allowPrivilegeEscalation: false
       serviceAccountName: training-operator

--- a/charts/apps/training-operator/templates/Deployment/training-operator-kubeflow-Deployment.yaml
+++ b/charts/apps/training-operator/templates/Deployment/training-operator-kubeflow-Deployment.yaml
@@ -53,7 +53,7 @@ spec:
             memory: 100Mi
           requests:
             cpu: 100m
-            memory: 100Mi
+            memory: 20Mi
         securityContext:
           allowPrivilegeEscalation: false
       serviceAccountName: training-operator

--- a/charts/apps/training-operator/templates/Deployment/training-operator-kubeflow-Deployment.yaml
+++ b/charts/apps/training-operator/templates/Deployment/training-operator-kubeflow-Deployment.yaml
@@ -53,7 +53,7 @@ spec:
             memory: 100Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 60Mi
         securityContext:
           allowPrivilegeEscalation: false
       serviceAccountName: training-operator

--- a/charts/common/dex/templates/ConfigMap/dex-auth-ConfigMap.yaml
+++ b/charts/common/dex/templates/ConfigMap/dex-auth-ConfigMap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  config.yaml: |- {{- mergeOverwrite .Values.default_config .Values.config | toYaml | nindent 4 }}
+  config.yaml: | {{- mergeOverwrite .Values.default_config .Values.config | toYaml | nindent 4 }}
 kind: ConfigMap
 metadata:
   name: dex

--- a/charts/common/dex/templates/ConfigMap/dex-auth-ConfigMap.yaml
+++ b/charts/common/dex/templates/ConfigMap/dex-auth-ConfigMap.yaml
@@ -1,32 +1,6 @@
 apiVersion: v1
 data:
-  config.yaml: |
-    issuer: http://dex.auth.svc.cluster.local:5556/dex
-    storage:
-      type: kubernetes
-      config:
-        inCluster: true
-    web:
-      http: 0.0.0.0:5556
-    logger:
-      level: "debug"
-      format: text
-    oauth2:
-      skipApprovalScreen: true
-    enablePasswordDB: true
-    staticPasswords:
-    - email: user@example.com
-      hash: $2y$12$4K/VkmDd1q1Orb3xAt82zu8gk7Ad6ReFR4LCP9UeYE90NLiN9Df72
-      # https://github.com/dexidp/dex/pull/1601/commits
-      # FIXME: Use hashFromEnv instead
-      username: user
-      userID: "15841185641784"
-    staticClients:
-    # https://github.com/dexidp/dex/pull/1664
-    - idEnv: OIDC_CLIENT_ID
-      redirectURIs: ["/login/oidc"]
-      name: 'Dex Login Application'
-      secretEnv: OIDC_CLIENT_SECRET
+  config.yaml: |- {{- mergeOverwrite .Values.default_config .Values.config | toYaml | nindent 4 }}
 kind: ConfigMap
 metadata:
   name: dex

--- a/charts/common/dex/values.yaml
+++ b/charts/common/dex/values.yaml
@@ -1,2 +1,28 @@
-null
-...
+config: {}
+default_config: 
+  issuer: http://dex.auth.svc.cluster.local:5556/dex
+  storage:
+    type: kubernetes
+    config:
+      inCluster: true
+  web:
+    http: 0.0.0.0:5556
+  logger:
+    level: "debug"
+    format: text
+  oauth2:
+    skipApprovalScreen: true
+  enablePasswordDB: true
+  staticPasswords:
+  - email: user@example.com
+    hash: $2y$12$4K/VkmDd1q1Orb3xAt82zu8gk7Ad6ReFR4LCP9UeYE90NLiN9Df72
+    # https://github.com/dexidp/dex/pull/1601/commits
+    # FIXME: Use hashFromEnv instead
+    username: user
+    userID: "15841185641784"
+  staticClients:
+  # https://github.com/dexidp/dex/pull/1664
+  - idEnv: OIDC_CLIENT_ID
+    redirectURIs: ["/login/oidc"]
+    name: 'Dex Login Application'
+    secretEnv: OIDC_CLIENT_SECRET

--- a/charts/common/istio-1-14/templates/Deployment/istio-ingressgateway-istio-system-Deployment.yaml
+++ b/charts/common/istio-1-14/templates/Deployment/istio-ingressgateway-istio-system-Deployment.yaml
@@ -11,6 +11,7 @@ metadata:
   name: istio-ingressgateway
   namespace: istio-system
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: istio-ingressgateway

--- a/charts/common/istio-1-14/templates/Deployment/istiod-istio-system-Deployment.yaml
+++ b/charts/common/istio-1-14/templates/Deployment/istiod-istio-system-Deployment.yaml
@@ -11,7 +11,7 @@ metadata:
   name: istiod
   namespace: istio-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       istio: pilot

--- a/charts/common/knative-eventing/templates/HorizontalPodAutoscaler/eventing-webhook-knative-eventing-HorizontalPodAutoscaler.yaml
+++ b/charts/common/knative-eventing/templates/HorizontalPodAutoscaler/eventing-webhook-knative-eventing-HorizontalPodAutoscaler.yaml
@@ -18,7 +18,7 @@ spec:
         averageUtilization: 100
         type: Utilization
     type: Resource
-  minReplicas: 1
+  minReplicas: 2
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/charts/common/knative-eventing/templates/PodDisruptionBudget/eventing-webhook-knative-eventing-PodDisruptionBudget.yaml
+++ b/charts/common/knative-eventing/templates/PodDisruptionBudget/eventing-webhook-knative-eventing-PodDisruptionBudget.yaml
@@ -10,7 +10,7 @@ metadata:
   name: eventing-webhook
   namespace: knative-eventing
 spec:
-  minAvailable: 80%
+  minAvailable: 1
   selector:
     matchLabels:
       app: eventing-webhook

--- a/charts/common/knative-serving/templates/HorizontalPodAutoscaler/activator-knative-serving-HorizontalPodAutoscaler.yaml
+++ b/charts/common/knative-serving/templates/HorizontalPodAutoscaler/activator-knative-serving-HorizontalPodAutoscaler.yaml
@@ -17,7 +17,7 @@ spec:
         averageUtilization: 100
         type: Utilization
     type: Resource
-  minReplicas: 1
+  minReplicas: 2
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/charts/common/knative-serving/templates/HorizontalPodAutoscaler/webhook-knative-serving-HorizontalPodAutoscaler.yaml
+++ b/charts/common/knative-serving/templates/HorizontalPodAutoscaler/webhook-knative-serving-HorizontalPodAutoscaler.yaml
@@ -17,7 +17,7 @@ spec:
         averageUtilization: 100
         type: Utilization
     type: Resource
-  minReplicas: 1
+  minReplicas: 2
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/charts/common/knative-serving/templates/PodDisruptionBudget/activator-pdb-knative-serving-PodDisruptionBudget.yaml
+++ b/charts/common/knative-serving/templates/PodDisruptionBudget/activator-pdb-knative-serving-PodDisruptionBudget.yaml
@@ -9,7 +9,7 @@ metadata:
   name: activator-pdb
   namespace: knative-serving
 spec:
-  minAvailable: 80%
+  minAvailable: 1
   selector:
     matchLabels:
       app: activator

--- a/charts/common/knative-serving/templates/PodDisruptionBudget/webhook-pdb-knative-serving-PodDisruptionBudget.yaml
+++ b/charts/common/knative-serving/templates/PodDisruptionBudget/webhook-pdb-knative-serving-PodDisruptionBudget.yaml
@@ -9,7 +9,7 @@ metadata:
   name: webhook-pdb
   namespace: knative-serving
 spec:
-  minAvailable: 80%
+  minAvailable: 1
   selector:
     matchLabels:
       app: webhook

--- a/charts/common/oidc-authservice/templates/ConfigMap/oidc-authservice-parameters-istio-system-ConfigMap.yaml
+++ b/charts/common/oidc-authservice/templates/ConfigMap/oidc-authservice-parameters-istio-system-ConfigMap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
   OIDC_AUTH_URL: /dex/auth
-  OIDC_PROVIDER: http://dex.auth.svc.cluster.local:5556/dex
+  OIDC_PROVIDER: {{ .Values.oidc_provider }}
   OIDC_SCOPES: profile email groups
   PORT: '"8080"'
   REDIRECT_URL: /login/oidc

--- a/charts/common/oidc-authservice/values.yaml
+++ b/charts/common/oidc-authservice/values.yaml
@@ -1,2 +1,1 @@
-null
-...
+oidc_provider: http://dex.auth.svc.cluster.local:5556/dex

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -143,6 +143,7 @@ module "kubeflow_oidc_authservice" {
   source            = "../../../../iaac/terraform/common/oidc-authservice"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/oidc-authservice" 
+    values = [var.authservice_config]
   }
   addon_context = var.addon_context
   depends_on = [module.kubeflow_dex]

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -136,9 +136,7 @@ module "kubeflow_dex" {
   }
   addon_context = var.addon_context
   depends_on = [module.kubeflow_istio]
-  set_values = {
-    "config" = var.dex_config
-  }
+  config = var.dex_config
 }
 
 module "kubeflow_oidc_authservice" {

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -136,6 +136,9 @@ module "kubeflow_dex" {
   }
   addon_context = var.addon_context
   depends_on = [module.kubeflow_istio]
+  set_values = {
+    "config" = var.dex_config
+  }
 }
 
 module "kubeflow_oidc_authservice" {

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -133,10 +133,10 @@ module "kubeflow_dex" {
   source            = "../../../../iaac/terraform/common/dex"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/dex"
+    values = yamlencode(var.dex_config)
   }
   addon_context = var.addon_context
   depends_on = [module.kubeflow_istio]
-  config = var.dex_config
 }
 
 module "kubeflow_oidc_authservice" {

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -133,7 +133,7 @@ module "kubeflow_dex" {
   source            = "../../../../iaac/terraform/common/dex"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/dex"
-    values = yamlencode(var.dex_config)
+    values = [yamlencode(var.dex_config)]
   }
   addon_context = var.addon_context
   depends_on = [module.kubeflow_istio]

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -191,7 +191,7 @@ module "kubeflow_istio_resources" {
     chart = "${var.kf_helm_repo_path}/charts/common/kubeflow-istio-resources"
   }  
   addon_context = var.addon_context
-  depends_on = [module.kubeflow_roles]
+  depends_on = [module.kubeflow_istio]
 }
 
 module "filter_kfp_set_values" {
@@ -347,14 +347,15 @@ module "kubeflow_aws_telemetry" {
   depends_on = [module.kubeflow_training_operator]
 }
 
-# module "kubeflow_user_namespace" {
-#   source            = "../../../../iaac/terraform/common/user-namespace"
-#   helm_config = {
-#     chart = "${var.kf_helm_repo_path}/charts/common/user-namespace"
-#   }  
-#   addon_context = var.addon_context
-#   depends_on = [module.kubeflow_aws_telemetry]
-# }
+module "kubeflow_user_namespace" {
+  count = var.enable_default_user ? 1: 0
+  source            = "../../../../iaac/terraform/common/user-namespace"
+  helm_config = {
+    chart = "${var.kf_helm_repo_path}/charts/common/user-namespace"
+  }  
+  addon_context = var.addon_context
+  depends_on = [module.kubeflow_aws_telemetry]
+}
 
 module "ack_sagemaker" {
   source            = "../../../../iaac/terraform/common/ack-sagemaker-controller"

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -346,14 +346,14 @@ module "kubeflow_aws_telemetry" {
   depends_on = [module.kubeflow_training_operator]
 }
 
-module "kubeflow_user_namespace" {
-  source            = "../../../../iaac/terraform/common/user-namespace"
-  helm_config = {
-    chart = "${var.kf_helm_repo_path}/charts/common/user-namespace"
-  }  
-  addon_context = var.addon_context
-  depends_on = [module.kubeflow_aws_telemetry]
-}
+# module "kubeflow_user_namespace" {
+#   source            = "../../../../iaac/terraform/common/user-namespace"
+#   helm_config = {
+#     chart = "${var.kf_helm_repo_path}/charts/common/user-namespace"
+#   }  
+#   addon_context = var.addon_context
+#   depends_on = [module.kubeflow_aws_telemetry]
+# }
 
 module "ack_sagemaker" {
   source            = "../../../../iaac/terraform/common/ack-sagemaker-controller"

--- a/deployments/rds-s3/terraform/rds-s3-components/main.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/main.tf
@@ -133,7 +133,7 @@ module "kubeflow_dex" {
   source            = "../../../../iaac/terraform/common/dex"
   helm_config = {
     chart = "${var.kf_helm_repo_path}/charts/common/dex"
-    values = [yamlencode(var.dex_config)]
+    values = [var.dex_config]
   }
   addon_context = var.addon_context
   depends_on = [module.kubeflow_istio]

--- a/deployments/rds-s3/terraform/rds-s3-components/variables.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/variables.tf
@@ -131,8 +131,7 @@ variable "mlmdb_name" {
 
 variable "minio_service_region" {
   type        = string
-  default = null
-  description = "S3 service region. Change this field if the S3 bucket will be in a different region than the EKS cluster"
+  default = nudex_config= "S3 service region. Change this field if the S3 bucket will be in a different region than the EKS cluster"
 }
 
 variable "minio_service_host" {
@@ -184,4 +183,10 @@ variable "notebook_idleness_check_period" {
   description = "How frequently the controller should poll each Notebook to update its LAST_ACTIVITY_ANNOTATION (minutes)"
   type = string
   default = 5
+}
+
+variable "dex_config"{
+  description = "Config to merge into the Dex config file as a ConfigMap"
+  type = any
+  default = {}
 }

--- a/deployments/rds-s3/terraform/rds-s3-components/variables.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/variables.tf
@@ -188,12 +188,12 @@ variable "notebook_idleness_check_period" {
 
 variable "dex_config"{
   description = "Config to merge into the Dex config file as a ConfigMap"
-  type = any
-  default = {}
+  type = string
+  default = ""
 }
 
 variable "authservice_config"{
   description = "Config for the authservice ConfigMap"
-  type = any
-  default = {}
+  type = string
+  default = ""
 }

--- a/deployments/rds-s3/terraform/rds-s3-components/variables.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/variables.tf
@@ -197,3 +197,9 @@ variable "authservice_config"{
   type = string
   default = ""
 }
+
+variable "enable_default_user"{
+  description = "Whether to create the default user@example.com profile"
+  type = bool
+  default = true
+}

--- a/deployments/rds-s3/terraform/rds-s3-components/variables.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/variables.tf
@@ -191,3 +191,9 @@ variable "dex_config"{
   type = any
   default = {}
 }
+
+variable "authservice_config"{
+  description = "Config for the authservice ConfigMap"
+  type = any
+  default = {}
+}

--- a/deployments/rds-s3/terraform/rds-s3-components/variables.tf
+++ b/deployments/rds-s3/terraform/rds-s3-components/variables.tf
@@ -131,7 +131,8 @@ variable "mlmdb_name" {
 
 variable "minio_service_region" {
   type        = string
-  default = nudex_config= "S3 service region. Change this field if the S3 bucket will be in a different region than the EKS cluster"
+  default = null
+  description = "S3 service region. Change this field if the S3 bucket will be in a different region than the EKS cluster"
 }
 
 variable "minio_service_host" {

--- a/iaac/terraform/apps/profiles-and-kfam/main.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/main.tf
@@ -1,6 +1,6 @@
 data "github_repository_file" "profile_controller_policy" {
-  repository = "awslabs/kubeflow-manifests"
-  branch     = "release-v1.6.1-aws-b1.0.0"
+  repository = "ni/kubeflow-manifests"
+  branch     = "main"
   file       = "awsconfigs/infra_configs/iam_profile_controller_policy.json"
 }
 resource "aws_iam_policy" "profile_controller_policy" {

--- a/iaac/terraform/apps/profiles-and-kfam/main.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/main.tf
@@ -1,7 +1,12 @@
+data "github_repository_file" "profile_controller_policy" {
+  repository = "awslabs/kubeflow-manifests"
+  branch     = "main"
+  file       = "awsconfigs/infra_configs/iam_profile_controller_policy.json"
+}
 resource "aws_iam_policy" "profile_controller_policy" {
-  name_prefix        = "profile-controller-policy"
+  name_prefix = "profile-controller-policy"
   description = "IAM policy for the kubeflow pipelines profile controller"
-  policy        = "${file("../../../awsconfigs/infra_configs/iam_profile_controller_policy.json")}"
+  policy      = data.github_repository_file.profile_controller_policy.content
 }
 
 module "irsa" {

--- a/iaac/terraform/apps/profiles-and-kfam/main.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/main.tf
@@ -1,5 +1,5 @@
 data "github_repository_file" "profile_controller_policy" {
-  repository = "awslabs/kubeflow-manifests?ref=v1.6.1-aws-b1.0.0"
+  repository = "awslabs/kubeflow-manifests"
   branch     = "main"
   file       = "awsconfigs/infra_configs/iam_profile_controller_policy.json"
 }

--- a/iaac/terraform/apps/profiles-and-kfam/main.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/main.tf
@@ -1,6 +1,6 @@
 data "github_repository_file" "profile_controller_policy" {
   repository = "awslabs/kubeflow-manifests"
-  branch     = "main"
+  branch     = "release-v1.6.1-aws-b1.0.0"
   file       = "awsconfigs/infra_configs/iam_profile_controller_policy.json"
 }
 resource "aws_iam_policy" "profile_controller_policy" {

--- a/iaac/terraform/apps/profiles-and-kfam/main.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/main.tf
@@ -1,5 +1,5 @@
 data "github_repository_file" "profile_controller_policy" {
-  repository = "awslabs/kubeflow-manifests"
+  repository = "awslabs/kubeflow-manifests?ref=v1.6.1-aws-b1.0.0"
   branch     = "main"
   file       = "awsconfigs/infra_configs/iam_profile_controller_policy.json"
 }

--- a/iaac/terraform/apps/profiles-and-kfam/versions.tf
+++ b/iaac/terraform/apps/profiles-and-kfam/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 2.13.1"
     }
+    github = {
+      source  = "integrations/github"
+      version = ">= 5.16.0"
+    }
   }
 }

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -1,7 +1,12 @@
+data "github_repository_file" "profile_controller_policy" {
+  repository = "awslabs/kubeflow-manifests"
+  branch     = "main"
+  file       = "awsconfigs/infra_configs/iam_ack_oidc_sm_studio_policy.json"
+}
 resource "aws_iam_policy" "sagemaker_ack_controller_studio_access" {
-  name_prefix        = "${local.service}-ack-controller-policy"
+  name_prefix = "${local.service}-ack-controller-policy"
   description = "IAM policy for the ${local.service} ack controller"
-  policy        = "${file("../../../awsconfigs/infra_configs/iam_ack_oidc_sm_studio_policy.json")}"
+  policy      = data.github_repository_file.profile_controller_policy.content
 }
 
 module "irsa" {

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -1,5 +1,5 @@
 data "github_repository_file" "profile_controller_policy" {
-  repository = "awslabs/kubeflow-manifests?ref=v1.6.1-aws-b1.0.0"
+  repository = "awslabs/kubeflow-manifests"
   branch     = "main"
   file       = "awsconfigs/infra_configs/iam_ack_oidc_sm_studio_policy.json"
 }

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -1,5 +1,5 @@
 data "github_repository_file" "profile_controller_policy" {
-  repository = "awslabs/kubeflow-manifests"
+  repository = "awslabs/kubeflow-manifests?ref=v1.6.1-aws-b1.0.0"
   branch     = "main"
   file       = "awsconfigs/infra_configs/iam_ack_oidc_sm_studio_policy.json"
 }

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -1,6 +1,6 @@
 data "github_repository_file" "profile_controller_policy" {
-  repository = "awslabs/kubeflow-manifests"
-  branch     = "release-v1.6.1-aws-b1.0.0"
+  repository = "ni/kubeflow-manifests"
+  branch     = "main"
   file       = "awsconfigs/infra_configs/iam_ack_oidc_sm_studio_policy.json"
 }
 resource "aws_iam_policy" "sagemaker_ack_controller_studio_access" {

--- a/iaac/terraform/common/ack-sagemaker-controller/main.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/main.tf
@@ -1,6 +1,6 @@
 data "github_repository_file" "profile_controller_policy" {
   repository = "awslabs/kubeflow-manifests"
-  branch     = "main"
+  branch     = "release-v1.6.1-aws-b1.0.0"
   file       = "awsconfigs/infra_configs/iam_ack_oidc_sm_studio_policy.json"
 }
 resource "aws_iam_policy" "sagemaker_ack_controller_studio_access" {

--- a/iaac/terraform/common/ack-sagemaker-controller/versions.tf
+++ b/iaac/terraform/common/ack-sagemaker-controller/versions.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = ">= 2.13.1"
     }
+    github = {
+      source  = "integrations/github"
+      version = ">= 5.16.0"
+    }
   }
 }

--- a/iaac/terraform/common/dex/main.tf
+++ b/iaac/terraform/common/dex/main.tf
@@ -2,10 +2,5 @@ module "helm_addon" {
   source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
   helm_config       = local.helm_config
   addon_context     = var.addon_context
-  set_values        = [ 
-    {
-      name = "config"
-      value = var.config
-    }
-  ]
+  values            = yamlencode(var.config)
 }

--- a/iaac/terraform/common/dex/main.tf
+++ b/iaac/terraform/common/dex/main.tf
@@ -2,5 +2,4 @@ module "helm_addon" {
   source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
   helm_config       = local.helm_config
   addon_context     = var.addon_context
-  values            = yamlencode(var.config)
 }

--- a/iaac/terraform/common/dex/main.tf
+++ b/iaac/terraform/common/dex/main.tf
@@ -2,4 +2,5 @@ module "helm_addon" {
   source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
   helm_config       = local.helm_config
   addon_context     = var.addon_context
+  set_values        = [var.config]
 }

--- a/iaac/terraform/common/dex/main.tf
+++ b/iaac/terraform/common/dex/main.tf
@@ -2,5 +2,10 @@ module "helm_addon" {
   source            = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons/helm-addon?ref=v4.12.1"
   helm_config       = local.helm_config
   addon_context     = var.addon_context
-  set_values        = [var.config]
+  set_values        = [ 
+    {
+      name = "config"
+      value = var.config
+    }
+  ]
 }

--- a/iaac/terraform/common/dex/variables.tf
+++ b/iaac/terraform/common/dex/variables.tf
@@ -19,3 +19,8 @@ variable "addon_context" {
   })
   description = "Input configuration for the addon"
 }
+
+variable "config" {
+  type        = any
+  default     = {}
+}


### PR DESCRIPTION
## **Which issue is resolved by this Pull Request:**

---
#### 1 - Relative paths to policy files
`aws_iam_policy` was resolved from a relative path that's incorrect if you use a dependent Terraform module directly.

In our case we were using the following modules:
- iaac/terraform/utils/blueprints-extended-outputs
- deployments/rds-s3/terraform/rds-s3-components

---
#### 2 - Do not create the default user
We do not want the default `user@example.com` user created on the cluster. We will do that in our own Terraform module.

---
#### 3 - Allow custom configuration of Dex and the `oidc_authservice`
Values for `dex` and the `oidc_authservice` needed to be configurable.

---
#### 4 - Increase memory limit for the `training_operator`
The pod was using about 54Mi so we needed this increased to 60Mi request and 100Mi max.

---
## **Description of your changes:**
- Used `github_repository_file` to download the contents directly from GitHub.
- Hardcoded the repo to `awslabs`
- Added the required provider `integrations/github` to each module and set the version to `5.16.0` to get the newest bug fixes to that provider ([see release tag](https://github.com/integrations/terraform-provider-github/releases/tag/v5.16.0))
- Increased the max and request memory size for the `training_operator`
- Commented out the helm chart that installed the default user
- Piped through values used to overwrite the default ConfigMaps for `Dex` and the `oidc_authservice`
---

## **Testing:**
- [ ] Unit tests pass
- [ ] e2e tests pass
- Details about new tests (If this PR adds a new feature)
- Details about any manual tests performed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.